### PR TITLE
Don't add Firefox variants for non-Firefox applications

### DIFF
--- a/pageload-summary/summarize.py
+++ b/pageload-summary/summarize.py
@@ -164,10 +164,11 @@ def organize_data(
         if "warm" in extras:
             pl_type = "warm"
 
-        if "fission" in extras:
-            variants += "fission-"
-        if "webrender" in extras:
-            variants += "webrender"
+        if app not in ("chrome", "chromium"):
+            if "fission" in extras:
+                variants += "fission-"
+            if "webrender" in extras:
+                variants += "webrender"
 
         # Newer data no longer has the nocondprof option
         if "nocondprof" in extras:


### PR DESCRIPTION
It looks like for a brief moment we recently had Chrome results with the "fission" extra option. This patch ensures that any Firefox only variants do not apply to the calculation for Chrome.