### PR TITLE
Make the matplotlib dependency optional.

### DIFF
--- a/mozperftest_tools/mozperftest_tools/side_by_side.py
+++ b/mozperftest_tools/mozperftest_tools/side_by_side.py
@@ -12,7 +12,6 @@ import json
 import shutil
 import subprocess
 
-from matplotlib import pyplot as plt
 from scipy.stats import spearmanr
 
 try:
@@ -68,6 +67,12 @@ class SideBySide:
 
     def generate_step_chart(self, oldvid, newvid, vismetPath, prefix, metric, output):
         print("Generating step chart for %s" % metric)
+
+        try:
+            from matplotlib import pyplot as plt
+        except Exception:
+            print("Please install matplotlib before using step charts")
+            raise
 
         oldvid_metrics = json.loads(
             subprocess.check_output(
@@ -339,6 +344,12 @@ class SideBySide:
         Returns:
             A dictionary containing the worst pairing and the 3D similarity score.
         """
+
+        try:
+            from matplotlib import pyplot as plt
+        except Exception:
+            print("Please install matplotlib before using the similarity metric")
+            raise
 
         def _get_frames(video):
             """Gets all frames from a video into a list."""

--- a/mozperftest_tools/setup.py
+++ b/mozperftest_tools/setup.py
@@ -3,10 +3,10 @@ import sys
 import setuptools
 
 PACKAGE_NAME = "mozperftest_tools"
-PACKAGE_VERSION = "0.1.1"
+PACKAGE_VERSION = "0.1.3"
 
 # dependencies
-deps = ["matplotlib", "opencv-python", "requests"]
+deps = ["opencv-python", "requests"]
 if sys.version_info <= (3, 7):
     # With versions <=3.7, we need to explicitly set
     # the max version or else pip will try to get the


### PR DESCRIPTION
This patch makes the `matplotlib` dependency optional by hiding it within the methods that use them.