### PR TITLE
Bump python_requires version cap

### DIFF
--- a/mozperftest_tools/setup.py
+++ b/mozperftest_tools/setup.py
@@ -48,5 +48,5 @@ setuptools.setup(
     package_dir={"mozperftest_tools": "mozperftest_tools"},
     install_requires=deps,
     packages=setuptools.find_packages(where="."),
-    python_requires=">=3.6, <3.10",
+    python_requires=">=3.6, <3.11",
 )


### PR DESCRIPTION
I previously had to downgrade my python to install mozperftest-tools locally but i'd prefer to stay on 3.10. (I was mainly using artifact downloader, but figure this might be useful to bump up for others)

doing this seems to work- any reason to not bump this?